### PR TITLE
Add printer discovery feature with SNMP

### DIFF
--- a/app/printer_discovery.py
+++ b/app/printer_discovery.py
@@ -1,0 +1,44 @@
+import asyncio
+import ipaddress
+from typing import List, Dict
+
+SYS_DESCR_OID = '1.3.6.1.2.1.1.1.0'
+SERIAL_OID = '1.3.6.1.2.1.43.5.1.1.17.1'
+
+
+def _snmp_get(ip: str, oid: str, community: str = 'public') -> str | None:
+    """Perform a simple SNMP GET operation."""
+    try:
+        from pysnmp.hlapi.v1arch.asyncio import CommunityData, UdpTransportTarget, ContextData, ObjectType, ObjectIdentity, cmdgen
+        from pysnmp.entity.engine import SnmpEngine
+
+        async def run() -> str | None:
+            errorIndication, errorStatus, errorIndex, varBinds = await cmdgen.get_cmd(
+                SnmpEngine(),
+                CommunityData(community),
+                UdpTransportTarget((ip, 161), timeout=1, retries=0),
+                ContextData(),
+                ObjectType(ObjectIdentity(oid))
+            )
+            if errorIndication or errorStatus:
+                return None
+            return str(varBinds[0][1])
+
+        return asyncio.get_event_loop().run_until_complete(run())
+    except Exception:
+        return None
+
+
+def discover_printers(subnet: str) -> List[Dict[str, str]]:
+    """Scan the given subnet for network printers using SNMP."""
+    printers: List[Dict[str, str]] = []
+    network = ipaddress.ip_network(subnet, strict=False)
+    for ip in network.hosts():
+        ip_str = str(ip)
+        descr = _snmp_get(ip_str, SYS_DESCR_OID)
+        if not descr:
+            continue
+        model = descr.split()[0]
+        serial = _snmp_get(ip_str, SERIAL_OID) or ''
+        printers.append({'ip': ip_str, 'model': model, 'serial_number': serial})
+    return printers

--- a/app/templates/admin_printers.html
+++ b/app/templates/admin_printers.html
@@ -9,6 +9,9 @@
         <button id="refreshSnmpData" class="btn btn-outline-info">
             <i class="bi bi-arrow-clockwise me-1"></i>Refresh SNMP Data
         </button>
+        <button id="discoverPrinters" class="btn btn-outline-success">
+            <i class="bi bi-search me-1"></i>Discover Printers
+        </button>
         <a href="{{ url_for('main.admin') }}" class="btn btn-outline-secondary">
             <i class="bi bi-arrow-left me-1"></i>Back to Admin
         </a>
@@ -222,6 +225,33 @@ document.addEventListener('DOMContentLoaded', function() {
     // Refresh button click handler
     document.getElementById('refreshSnmpData').addEventListener('click', function() {
         refreshSNMPData();
+    });
+
+    // Discover printers button
+    document.getElementById('discoverPrinters').addEventListener('click', function() {
+        const subnet = prompt('Enter subnet to scan (e.g. 192.168.1.0/24):', '192.168.1.0/24');
+        if (!subnet) return;
+        const btn = this;
+        btn.disabled = true;
+        fetch(`/admin/printers/discover?subnet=${encodeURIComponent(subnet)}`)
+            .then(r => r.json())
+            .then(data => {
+                const printers = data.printers || [];
+                if (printers.length && confirm(`Add ${printers.length} printers to the database?`)) {
+                    fetch('/admin/printers/discover', {
+                        method: 'POST',
+                        headers: {'Content-Type': 'application/json'},
+                        body: JSON.stringify({printers})
+                    }).then(res => res.json()).then(res => {
+                        if (res.success) { location.reload(); }
+                        else { showToast('Error adding printers', 'error'); }
+                    });
+                } else if (!printers.length) {
+                    showToast('No printers found', 'info');
+                }
+            })
+            .catch(() => showToast('Error discovering printers', 'error'))
+            .finally(() => { btn.disabled = false; });
     });
 });
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,4 +15,5 @@ dependencies = [
     "apscheduler>=3.11.0",
     "pypdf2>=3.0.1",
     "pillow>=11.2.1",
+    "pysnmp>=7.1.21",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ flask-migrate
 python-dotenv
 qrcode
 watchdog
+pysnmp>=7.1.21

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+
+@pytest.fixture
+def app(monkeypatch):
+    from app import create_app
+    # Prevent LPR server from starting
+    monkeypatch.setattr('app.lpr_server.start_lpr_server', lambda app: None)
+    app = create_app()
+    with app.app_context():
+        yield app
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def admin_client(client):
+    client.post('/login', data={'username': 'admin', 'password': 'admin123'})
+    return client

--- a/tests/test_printer_discovery.py
+++ b/tests/test_printer_discovery.py
@@ -1,0 +1,49 @@
+import json
+from app.printer_discovery import discover_printers
+from app.models import Printer
+
+
+def test_discover_printers(monkeypatch):
+    responses = {
+        '192.168.1.9': None,
+        '192.168.1.10': {
+            '1.3.6.1.2.1.1.1.0': 'HP LaserJet',
+            '1.3.6.1.2.1.43.5.1.1.17.1': 'SN123'
+        }
+    }
+
+    def fake_get(ip, oid, community='public'):
+        data = responses.get(ip, {})
+        if data:
+            return data.get(oid)
+        return None
+
+    monkeypatch.setattr('app.printer_discovery._snmp_get', fake_get)
+    printers = discover_printers('192.168.1.8/30')
+    assert printers == [{'ip': '192.168.1.10', 'model': 'HP', 'serial_number': 'SN123'}]
+
+
+def test_discover_route_adds_printers(admin_client, monkeypatch):
+    data = {
+        '192.168.1.10': {
+            '1.3.6.1.2.1.1.1.0': 'Canon Printer',
+            '1.3.6.1.2.1.43.5.1.1.17.1': 'SN999'
+        }
+    }
+
+    def fake_get(ip, oid, community='public'):
+        vals = data.get(ip, {})
+        return vals.get(oid)
+
+    monkeypatch.setattr('app.printer_discovery._snmp_get', fake_get)
+    resp = admin_client.get('/admin/printers/discover?subnet=192.168.1.8/30')
+    result = json.loads(resp.data)
+    assert len(result['printers']) == 1
+
+    # Post to create
+    post_resp = admin_client.post('/admin/printers/discover', json={'printers': result['printers']})
+    assert post_resp.json['success']
+
+    printers = Printer.query.all()
+    assert len(printers) == 1
+    assert printers[0].ip_address == '192.168.1.10'


### PR DESCRIPTION
## Summary
- implement `discover_printers` utility using pysnmp
- expose admin route `/admin/printers/discover` to scan subnet and create printers
- add button in admin template to trigger discovery via JavaScript
- include pysnmp dependency
- add tests for discovery logic and route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863dc44b8f88329bf3c11e978a94204