### PR TITLE
Add print queue admin page

### DIFF
--- a/app/blueprints/admin.py
+++ b/app/blueprints/admin.py
@@ -9,7 +9,15 @@ from datetime import datetime, timedelta
 from sqlalchemy import func, desc
 
 from .. import db
-from ..models import User, PrintJob, Department, SystemSettings, Printer, PrintPolicy
+from ..models import (
+    User,
+    PrintJob,
+    Department,
+    SystemSettings,
+    Printer,
+    PrintPolicy,
+    PrintQueue,
+)
 from ..utils import calculate_environmental_impact
 
 admin_bp = Blueprint('admin', __name__, url_prefix='/admin')
@@ -346,3 +354,12 @@ def update_settings():
     db.session.commit()
     flash('Settings updated successfully', 'success')
     return redirect(url_for('admin.settings'))
+
+
+@admin_bp.route('/print-queue')
+@login_required
+@admin_required
+def print_queue():
+    """View incoming LPR jobs saved in the print queue"""
+    queue = PrintQueue.query.order_by(PrintQueue.timestamp.desc()).all()
+    return render_template('admin/print_queue.html', queue=queue)

--- a/app/templates/admin/print_queue.html
+++ b/app/templates/admin/print_queue.html
@@ -1,0 +1,49 @@
+{% extends "base.html" %}
+
+{% block title %}Print Queue - Print Manager{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h2><i class="bi bi-stack me-2"></i>Print Queue</h2>
+    <a href="{{ url_for('admin.dashboard') }}" class="btn btn-outline-secondary">
+        <i class="bi bi-arrow-left me-1"></i>Back to Admin
+    </a>
+</div>
+
+<div class="card">
+    <div class="card-body">
+        {% if queue %}
+        <div class="table-responsive">
+            <table class="table table-hover">
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Filename</th>
+                        <th>User</th>
+                        <th>IP</th>
+                        <th>Status</th>
+                        <th>Queue</th>
+                        <th>Received</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for job in queue %}
+                    <tr>
+                        <td>{{ job.id }}</td>
+                        <td>{{ job.filename }}</td>
+                        <td>{{ job.username or 'N/A' }}</td>
+                        <td>{{ job.user_ip }}</td>
+                        <td>{{ job.status }}</td>
+                        <td>{{ job.queue_name or '-' }}</td>
+                        <td>{{ job.timestamp.strftime('%Y-%m-%d %H:%M:%S') }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% else %}
+            <p class="mb-0">No jobs in the queue.</p>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -80,6 +80,9 @@
                                     <li><a class="dropdown-item" href="{{ url_for('main.admin_policies') }}">
                                         <i class="bi bi-shield-check me-1"></i>Print Policies
                                     </a></li>
+                                    <li><a class="dropdown-item" href="{{ url_for('admin.print_queue') }}">
+                                        <i class="bi bi-stack me-1"></i>Print Queue
+                                    </a></li>
                                     <li><hr class="dropdown-divider"></li>
                                     <li><a class="dropdown-item" href="{{ url_for('main.admin_email_to_print') }}">
                                         <i class="bi bi-envelope me-1"></i>Email-to-Print

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,9 @@ os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
 def app(monkeypatch):
     from app import create_app
     # Prevent LPR server from starting
-    monkeypatch.setattr('app.lpr_server.start_lpr_server', lambda app: None)
+    monkeypatch.setattr('app.start_lpr_server', lambda app: None)
+    # Prevent scheduler from running during tests
+    monkeypatch.setattr('app.scheduler.start', lambda *a, **k: None)
     app = create_app()
     with app.app_context():
         yield app

--- a/tests/test_admin_print_queue.py
+++ b/tests/test_admin_print_queue.py
@@ -1,0 +1,10 @@
+from app.models import PrintQueue, db
+
+def test_print_queue_page(admin_client, app):
+    with app.app_context():
+        job = PrintQueue(filename='testfile.pdf', user_ip='127.0.0.1')
+        db.session.add(job)
+        db.session.commit()
+    resp = admin_client.get('/admin/print-queue')
+    assert resp.status_code == 200
+    assert b'testfile.pdf' in resp.data


### PR DESCRIPTION
## Summary
- add PrintQueue model import and route to admin blueprint
- create template showing pending queue
- link new page in admin dropdown
- test the new admin route
- prevent scheduler from running in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863e17e1bb88329850ff84307065d7e